### PR TITLE
Fixes #346 - Continued dependabot to group scheduled updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,14 @@ updates:
       - dependency-name: "django"
         versions:
           - "> 4.2"  # This ignores versions above 4.2, allowing only 4.2.x LTS upgrades
+    groups:
+      all-python-dependencies:
+        pattern: "*"
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    groups:
+      all-npm-dependencies:
+        pattern: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - "> 4.2"  # This ignores versions above 4.2, allowing only 4.2.x LTS upgrades
     groups:
       all-python-dependencies:
-        pattern: "*"
+        patterns: ["*"]
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -26,4 +26,4 @@ updates:
       interval: "weekly"
     groups:
       all-npm-dependencies:
-        pattern: "*"
+        patterns: ["*"]


### PR DESCRIPTION
This seems like it should be enough to configure the grouped dependencies. This groups everything. This could be further configured to create more specific groups. 