### PR TITLE
Upgrade node and Dockerfile to get to build on Openshift

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -8,7 +8,6 @@ COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
-    default-libmysqlclient-dev \
     netcat-openbsd \
     vim-tiny \
     jq \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 # FROM directive instructing base image to build upon
 # This could be used as a base instead: 
 # https://hub.docker.com/r/nikolaik/python-nodejs
-FROM python:3.10-slim-bookworm
+FROM python:3.10-slim
 
 # NOTE: requirements.txt not likely to change between dev builds
 COPY requirements.txt .
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /code/frontend
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt install -y nodejs
 
 COPY /frontend/package*.json /code/frontend

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -14,10 +14,15 @@ FROM image-registry.openshift-image-registry.svc:5000/openshift/python:3.10-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential default-libmysqlclient-dev netcat vim-tiny jq python3-dev git supervisor curl && \
+    build-essential netcat-openbsd vim-tiny jq python3-dev git supervisor curl pkg-config && \
     apt-get upgrade -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
+
+# Install MariaDB from the mariadb repository rather than using Debians 
+# https://mariadb.com/kb/en/mariadb-package-repository-setup-and-usage/
+RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash && \
+apt install -y --no-install-recommends libmariadb-dev
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -1,6 +1,6 @@
 # node-build stage
 
-FROM docker-registry.default.svc:5000/openshift/node:16-slim AS node-build
+FROM image-registry.openshift-image-registry.svc:5000/openshift/node:20-slim AS node-build
 WORKDIR /build/
 
 COPY frontend .
@@ -10,7 +10,7 @@ RUN npm run build:frontend
 
 # main stage
 
-FROM docker-registry.default.svc:5000/openshift/python:3.8-slim AS main
+FROM image-registry.openshift-image-registry.svc:5000/openshift/python:3.10-slim AS main
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Fixes #354
The 3.10-slim is the same as 3.10-slim-bookworm, but this one exists in Openshift